### PR TITLE
Made storage engine pluggable and configurable with and between LevelDB and RocksDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 CC = gcc
 CXX = g++
-CFLAGS = -Iinclude -Ivendor/leveldb/include -Ivendor/googletest/googletest/include -Ivendor/googletest/googletest -Ivendor/uthash/src -Ivendor/log/src -Wall -g
+CFLAGS = -Iinclude -Ivendor/leveldb/include -Ivendor/rocksdb/include -Ivendor/googletest/googletest/include -Ivendor/googletest/googletest -Ivendor/uthash/src -Ivendor/log/src -Wall -g
 CXXFLAGS = $(CFLAGS) -std=c++17 -isystem vendor/leveldb/third_party/benchmark/include
-LDFLAGS = -lstdc++ -pthread
+LDFLAGS = -lstdc++ -pthread -lz -lbz2 -lsnappy -llz4 -lzstd
 
 SRC_DIR = src
 LIB_DIR = lib
@@ -13,8 +13,10 @@ LIB_NAME = liblevelcache.a
 LIB_TARGET = $(LIB_DIR)/$(LIB_NAME)
 
 LEVELDB_LIB = vendor/leveldb/libleveldb.a
+ROCKSDB_LIB = vendor/rocksdb/librocksdb.a
 
-SRC_FILES = src/levelcache.c vendor/log/src/log.c
+SRC_FILES = src/levelcache.c vendor/log/src/log.c \
+	    src/leveldb_adapter.c src/rocksdb_adapter.c
 OBJ_FILES = $(patsubst src/%.c,$(OBJ_DIR)/src/%.o,$(filter src/%.c,$(SRC_FILES)))
 OBJ_FILES += $(patsubst vendor/log/src/%.c,$(OBJ_DIR)/vendor/log/src/%.o,$(filter vendor/log/src/%.c,$(SRC_FILES)))
 
@@ -34,11 +36,14 @@ BENCHMARK_RUNNER = $(BIN_DIR)/benchmark_runner
 
 .PHONY: all clean test leveldb benchmark
 
-all: leveldb $(LIB_TARGET)
+all: leveldb rocksdb $(LIB_TARGET)
 
 leveldb:
 	@echo "Building leveldb and its dependencies..."
 	@cd vendor/leveldb && cmake -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS=-fPIC . > /dev/null && $(MAKE) --no-print-directory
+rocksdb:
+	@echo "Building rocksdb..."
+	@$(MAKE) -C vendor/rocksdb static_lib
 
 $(LIB_TARGET): $(OBJ_FILES)
 	@mkdir -p $(LIB_DIR)
@@ -73,14 +78,14 @@ test: leveldb $(LIB_TARGET) $(TEST_RUNNER)
 
 $(TEST_RUNNER): $(LIB_TARGET) $(GTEST_OBJ_FILES) $(TEST_OBJ_FILES)
 	@mkdir -p $(BIN_DIR)
-	$(CXX) $(CXXFLAGS) -o $@ $(GTEST_OBJ_FILES) $(TEST_OBJ_FILES) $(LIB_TARGET) $(LEVELDB_LIB) $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -o $@ $(GTEST_OBJ_FILES) $(TEST_OBJ_FILES) $(LIB_TARGET) $(LEVELDB_LIB) $(ROCKSDB_LIB) $(LDFLAGS)
 
 benchmark: leveldb $(LIB_TARGET) $(BENCHMARK_RUNNER)
 	./$(BENCHMARK_RUNNER) --benchmark_min_time=2 --benchmark_repetitions=3
 
 $(BENCHMARK_RUNNER): $(LIB_TARGET) $(BENCHMARK_OBJ_FILES) $(GBENCHMARK_OBJ)
 	@mkdir -p $(BIN_DIR)
-	$(CXX) $(CXXFLAGS) -o $@ $(BENCHMARK_OBJ_FILES) $(GBENCHMARK_OBJ) $(LIB_TARGET) $(LEVELDB_LIB) $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -o $@ $(BENCHMARK_OBJ_FILES) $(GBENCHMARK_OBJ) $(LIB_TARGET) $(LEVELDB_LIB) $(ROCKSDB_LIB) $(LDFLAGS)
 
 clean:
 	rm -rf $(OBJ_DIR) $(BIN_DIR) $(LIB_DIR)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = gcc
 CXX = g++
 CFLAGS = -Iinclude -Ivendor/leveldb/include -Ivendor/rocksdb/include -Ivendor/googletest/googletest/include -Ivendor/googletest/googletest -Ivendor/uthash/src -Ivendor/log/src -Wall -g
 CXXFLAGS = $(CFLAGS) -std=c++17 -isystem vendor/leveldb/third_party/benchmark/include
-LDFLAGS = -lstdc++ -pthread -lz -lbz2 -lsnappy -llz4 -lzstd
+LDFLAGS = -lstdc++ -pthread -lz -lbz2 -lsnappy -llz4 -lzstd -luring
 
 SRC_DIR = src
 LIB_DIR = lib

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# LevelCache
+# flashcache
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-LevelCache is a high-performance, ephemeral, embedded key-value caching library written in C. It is built on top of Google's [LevelDB](https://github.com/google/leveldb) and provides a simple, clean API for caching with Time-to-Live (TTL) support.
+flashcache is a high-performance, ephemeral, embedded key-value caching library written in C. It is built on top of Google's [LevelDB](https://github.com/google/leveldb), facebook's [RocksDB](https://github.com/facebook/rocksdb), etc and provides a simple, clean API for caching with Time-to-Live (TTL) support.
 
 ## Features
 
@@ -14,11 +14,11 @@ LevelCache is a high-performance, ephemeral, embedded key-value caching library 
 
 ## Getting Started
 
-Getting started with levelcache is simple and a step by step guide is documented in [examples](examples) directory.
+Getting started with flashcache is simple and a step by step guide is documented in [examples](examples) directory.
 
 ## Makefile Targets
 
-- `all`: Builds the `liblevelcache.a` static library.
+- `all`: Builds the `libflashcache.a` static library.
 - `test`: Builds and runs the Google Test suite.
 - `benchmark`: Builds and runs the performance benchmark suite.
 - `clean`: Removes all build artifacts.

--- a/benchmark/gbenchmark.cpp
+++ b/benchmark/gbenchmark.cpp
@@ -8,7 +8,10 @@
 
 extern "C" {
 #include "levelcache.h"
+#include "storage_engine.h"
 }
+
+engine_t etype = ENGINE_ROCKSDB;
 
 const char* DB_PATH_BENCH = "/tmp/levelcache_gbenchmark_db";
 
@@ -36,7 +39,7 @@ public:
             char command[256];
             snprintf(command, sizeof(command), "rm -rf %s", DB_PATH_BENCH);
             system(command);
-            cache = levelcache_open(DB_PATH_BENCH, 100, 0, 0, LOG_FATAL); // 100 MB cache
+            cache = levelcache_open(DB_PATH_BENCH, 100, 0, 0, LOG_FATAL, ENGINE_ROCKSDB); // 100 MB cache
             if (!cache) {
                 // This is a fatal error for the benchmark suite.
                 // We use a raw fprintf and exit because this setup is outside the benchmark run state.

--- a/examples/main.c
+++ b/examples/main.c
@@ -8,7 +8,7 @@ int main() {
     const char* db_path = "/tmp/my_project_db";
 
     // Open the database with a 10MB cache
-    LevelCache* cache = levelcache_open(db_path, 10, 0, 0, LOG_INFO);
+    LevelCache* cache = levelcache_open(db_path, 10, 0, 0, LOG_INFO, 0); // 0 corresponds to leveldb
     if (cache == NULL) {
         fprintf(stderr, "Failed to open database.\n");
         return 1;

--- a/include/storage_engine.h
+++ b/include/storage_engine.h
@@ -1,0 +1,61 @@
+#ifndef STORAGE_ENGINE_H
+#define STORAGE_ENGINE_H
+
+#include <stddef.h>
+#include <stdbool.h>
+
+typedef enum engine_t { 
+    ENGINE_LEVELDB,
+    ENGINE_ROCKSDB,
+    LIMIT,
+} engine_t;
+
+static const char* engine_names[LIMIT] = { "leveldb", "rocksdb" };
+
+/**
+ * @brief i will write it later.
+ */
+
+typedef struct StorageEngine {
+    engine_t type;
+
+    // open/close
+    void* (*open)(void *options, const char *path, char **err);
+    void  (*close)(void *db);
+
+    // options
+    void* (*options_create)();
+    void  (*options_destroy)(void *options);
+    void  (*options_set_create_if_missing)(void *options, int v);
+    void  (*destroy_db)(void *options, const char *path, char **err);
+    
+    // Read/Write
+    void* (*readoptions_create)();
+    void* (*writeoptions_create)();
+    void  (*readoptions_destroy)(void *roptions);
+    void  (*writeoptions_destroy)(void *woptions);
+    void  (*put)(void *db, void *woptions, const char *key, size_t keylen,
+                const char *value, size_t valuelen, char **err);
+    char* (*get)(void *db, void *roptions, const char *key, size_t keylen,
+                size_t* valuelen, char **err);
+    void  (*del)(void *db, void *woptions, const char *key, size_t keylen,
+                char **err);
+
+    //cache
+    void* (*cache_create_lru)(size_t cache_size);
+    void  (*options_set_cache)(void *options, void *cache);
+    void  (*cache_destroy)(void *lru_cache);
+
+    //free function for db-allocated bufers (errors) 
+    //rocksdb uses free() but leveldb has its owd leveldb_free()
+    void  (*free_fn)(void *ptr);
+
+    bool supports_native_ttl;
+
+} StorageEngine;
+
+extern StorageEngine LEVELDB_ENGINE;
+extern StorageEngine ROCKSDB_ENGINE;
+
+#endif // STORAGE_ENGINE_H
+

--- a/src/levelcache.c
+++ b/src/levelcache.c
@@ -29,7 +29,7 @@ void *cleanup_thread_function(void *arg) {
     return NULL;
 }
 
-LevelCache* levelcache_open(const char *path, size_t max_memory_mb, uint32_t default_ttl_seconds, uint32_t cleanup_frequency_sec, int log_level, engine_t engine_type) {
+LevelCache* levelcache_open(const char *path, size_t max_memory_mb, uint32_t default_ttl_seconds, uint32_t cleanup_frequency_sec, int log_level, engine_t etype) {
     log_set_level(log_level);
     log_info("[open] Opening database at '%s'", path);
 
@@ -39,7 +39,14 @@ LevelCache* levelcache_open(const char *path, size_t max_memory_mb, uint32_t def
         return NULL;
     }
 
-    StorageEngine *engine = ALL_ENGINES[engine_type];
+    if (etype >= LIMIT && etype < 0) {
+        log_error("[open] Invalid engine type");
+        return NULL;
+    }
+
+    log_info("[open] Configured engine to %s", engine_names[etype]);
+
+    StorageEngine *engine = ALL_ENGINES[etype];
     
     cache->engine = engine;
     cache->index = NULL;

--- a/src/leveldb_adapter.c
+++ b/src/leveldb_adapter.c
@@ -1,0 +1,54 @@
+#include "../include/storage_engine.h"
+#include "leveldb/c.h"
+
+static void* ldb_open(void *options, const char *path, char **err) {
+    return leveldb_open((leveldb_options_t*)options, path, err);
+}
+static void ldb_close(void* db) { leveldb_close((leveldb_t*)db); }
+
+static void* ldb_options_create() { return leveldb_options_create(); }
+static void ldb_options_destroy(void* options) { leveldb_options_destroy((leveldb_options_t*)options); }
+static void ldb_options_set_create_if_missing(void *options, int v) { leveldb_options_set_create_if_missing((leveldb_options_t*)options, v); }
+static void ldb_destroy_db(void *options, const char *path, char **err) { leveldb_destroy_db((leveldb_options_t*)options, path, err); }
+
+static void* ldb_readoptions_create() { return leveldb_readoptions_create(); }
+static void* ldb_writeoptions_create() { return leveldb_writeoptions_create(); }
+static void ldb_readoptions_destroy(void *roptions) { leveldb_readoptions_destroy((leveldb_readoptions_t*)roptions); }
+static void ldb_writeoptions_destroy(void *woptions) { leveldb_writeoptions_destroy((leveldb_writeoptions_t*)woptions); }
+static void ldb_put(void *db, void *woptions, const char *key, size_t keylen, const char *value, size_t valuelen, char **err) {
+    leveldb_put((leveldb_t*)db, (leveldb_writeoptions_t*)woptions, key, keylen, value, valuelen, err);
+}
+static char* ldb_get(void *db, void *roptions, const char *key, size_t keylen, size_t *valuelen, char **err) {
+    return leveldb_get((leveldb_t*)db, (leveldb_readoptions_t*)roptions, key, keylen, valuelen, err);
+}
+static void ldb_del(void *db, void *woptions, const char *key, size_t klen, char **err) {
+    leveldb_delete((leveldb_t*)db, (leveldb_writeoptions_t*)woptions, key, klen, err);
+}
+
+static void* ldb_cache_create_lru(size_t capacity) { return leveldb_cache_create_lru(capacity); }
+static void ldb_options_set_cache(void *options, void *cache) { leveldb_options_set_cache((leveldb_options_t*)options, (leveldb_cache_t*)cache); }
+static void ldb_cache_destroy(void *cache) { leveldb_cache_destroy((leveldb_cache_t*)cache); }
+
+static void ldb_free(void *ptr) { leveldb_free(ptr); }
+
+StorageEngine LEVELDB_ENGINE = {
+    .type = ENGINE_LEVELDB,
+    .open = ldb_open,
+    .close = ldb_close,
+    .options_create = ldb_options_create,
+    .options_destroy = ldb_options_destroy,
+    .options_set_create_if_missing = ldb_options_set_create_if_missing,
+    .destroy_db = ldb_destroy_db,
+    .readoptions_create = ldb_readoptions_create,
+    .writeoptions_create = ldb_writeoptions_create,
+    .readoptions_destroy = ldb_readoptions_destroy,
+    .writeoptions_destroy = ldb_writeoptions_destroy,
+    .put = ldb_put,
+    .get = ldb_get,
+    .del = ldb_del,
+    .cache_create_lru = ldb_cache_create_lru,
+    .options_set_cache = ldb_options_set_cache,
+    .cache_destroy = ldb_cache_destroy,
+    .free_fn = ldb_free,
+    .supports_native_ttl = false,
+};

--- a/src/rocksdb_adapter.c
+++ b/src/rocksdb_adapter.c
@@ -1,0 +1,63 @@
+#include "../include/storage_engine.h"
+#include <stdlib.h>
+#include "rocksdb/c.h"
+
+static void* rdb_open(void *options, const char *path, char **err) {
+    return rocksdb_open((rocksdb_options_t*)options, path, err);
+}
+static void rdb_close(void* db) { rocksdb_close((rocksdb_t*)db); }
+
+static void* rdb_options_create() { return rocksdb_options_create(); }
+static void rdb_options_destroy(void* options) { rocksdb_options_destroy((rocksdb_options_t*)options); }
+static void rdb_options_set_create_if_missing(void *options, int v) { rocksdb_options_set_create_if_missing((rocksdb_options_t*)options, v); }
+static void rdb_destroy_db(void *options, const char *path, char **err) { rocksdb_destroy_db((rocksdb_options_t*)options, path, err); }
+
+static void* rdb_readoptions_create() { return rocksdb_readoptions_create(); }
+static void* rdb_writeoptions_create() { return rocksdb_writeoptions_create(); }
+static void rdb_readoptions_destroy(void *roptions) { rocksdb_readoptions_destroy((rocksdb_readoptions_t*)roptions); }
+static void rdb_writeoptions_destroy(void *woptions) { rocksdb_writeoptions_destroy((rocksdb_writeoptions_t*)woptions); }
+static void rdb_put(void *db, void *woptions, const char *key, size_t keylen, const char *value, size_t valuelen, char **err) {
+    rocksdb_put((rocksdb_t*)db, (rocksdb_writeoptions_t*)woptions, key, keylen, value, valuelen, err);
+}
+static char* rdb_get(void *db, void *roptions, const char *key, size_t keylen, size_t *valuelen, char **err) {
+    return rocksdb_get((rocksdb_t*)db, (rocksdb_readoptions_t*)roptions, key, keylen, valuelen, err);
+}
+static void rdb_del(void *db, void *woptions, const char *key, size_t klen, char **err) {
+    rocksdb_delete((rocksdb_t*)db, (rocksdb_writeoptions_t*)woptions, key, klen, err);
+}
+
+static void* rdb_cache_create_lru(size_t capacity) { return rocksdb_cache_create_lru(capacity); }
+//static void rdb_options_set_cache(void *options, void *cache) { rocksdb_options_set_cache((rocksdb_options_t*)options, (rocksdb_cache_t*)cache); }
+static void rdb_options_set_cache(void *options, void *cache) {
+    rocksdb_block_based_table_options_t* bbt_opts = rocksdb_block_based_options_create();
+    rocksdb_block_based_options_set_block_cache(bbt_opts, (rocksdb_cache_t*)cache);
+    rocksdb_options_set_block_based_table_factory((rocksdb_options_t*)options, bbt_opts);
+}
+
+static void rdb_cache_destroy(void *cache) { rocksdb_cache_destroy((rocksdb_cache_t*)cache); }
+
+static void rdb_free(void *ptr) { free(ptr); }
+
+StorageEngine ROCKSDB_ENGINE = {
+    .type = ENGINE_ROCKSDB,
+    .open = rdb_open,
+    .close = rdb_close,
+    .options_create = rdb_options_create,
+    .options_destroy = rdb_options_destroy,
+    .options_set_create_if_missing = rdb_options_set_create_if_missing,
+    .destroy_db = rdb_destroy_db,
+    .readoptions_create = rdb_readoptions_create,
+    .writeoptions_create = rdb_writeoptions_create,
+    .readoptions_destroy = rdb_readoptions_destroy,
+    .writeoptions_destroy = rdb_writeoptions_destroy,
+    .put = rdb_put,
+    .get = rdb_get,
+    .del = rdb_del,
+    .cache_create_lru = rdb_cache_create_lru,
+    .options_set_cache = rdb_options_set_cache,
+    .cache_destroy = rdb_cache_destroy,
+    .free_fn = rdb_free,
+    .supports_native_ttl = true, // RocksDB supports TTL natively
+};
+
+

--- a/tests/gtest_levelcache.cpp
+++ b/tests/gtest_levelcache.cpp
@@ -6,6 +6,8 @@ extern "C" {
 #include "log.h"
 }
 
+engine_t etype = ENGINE_LEVELDB;
+
 namespace {
 
 const char* DB_PATH = "/tmp/levelcache_test_db";
@@ -18,7 +20,7 @@ protected:
         char command[256];
         snprintf(command, sizeof(command), "rm -rf %s", DB_PATH);
         system(command);
-        cache = levelcache_open(DB_PATH, 0, 1, 0, LOG_FATAL);
+        cache = levelcache_open(DB_PATH, 0, 1, 0, LOG_FATAL, etype);
         ASSERT_NE(cache, nullptr);
     }
 
@@ -137,7 +139,7 @@ TEST_F(LevelCacheTest, EmptyValue) {
 
 TEST_F(LevelCacheTest, DefaultTtl) {
     levelcache_close(cache);
-    cache = levelcache_open(DB_PATH, 0, 2, 0, LOG_FATAL); // 2 seconds default TTL
+    cache = levelcache_open(DB_PATH, 0, 2, 0, LOG_FATAL, etype); // 2 seconds default TTL
     ASSERT_NE(cache, nullptr);
 
     const char *key = "default_ttl_key";
@@ -159,7 +161,7 @@ TEST_F(LevelCacheTest, DefaultTtl) {
 
 TEST_F(LevelCacheTest, CleanupThread) {
     levelcache_close(cache);
-    cache = levelcache_open(DB_PATH, 0, 1, 1, LOG_FATAL); // 1 second cleanup frequency
+    cache = levelcache_open(DB_PATH, 0, 1, 1, LOG_FATAL, etype); // 1 second cleanup frequency
     ASSERT_NE(cache, nullptr);
 
     const char *key1 = "key1";
@@ -191,7 +193,7 @@ TEST_F(LevelCacheTest, CleanupThread) {
 
 TEST_F(LevelCacheTest, LogLevel) {
     levelcache_close(cache);
-    cache = levelcache_open(DB_PATH, 0, 1, 0, LOG_INFO);
+    cache = levelcache_open(DB_PATH, 0, 1, 0, LOG_INFO, etype);
     ASSERT_NE(cache, nullptr);
     ASSERT_EQ(cache->log_level, LOG_INFO);
 }


### PR DESCRIPTION
This PR implements the issue #1 
Changes: 
- added StorageEngine abstraction (include/storage_engine.h) to unify DB operations
- implemented leveldb_adapter.c and rocksdb_adapter.c as adapters for each storage backend
- updated levelcache_open() to accept an engine_t parameter for engine selection
- updated internal LevelCache structures to use generic pointers (void*) for DB handles and options
- integrated RocksDB as a new submodule under vendor/rocksdb and added a build step for it in the Makefile
- updated examples/main.c to demonstrate opening LevelCache with a selected engine
- added additional linker flags for RocksDB dependencies (-lz -lbz2 -lsnappy -llz4 -lzstd)

**TODO** : 
- tests compatible to with the current changes
- benchmarks compatible to with the current changes

Hey let me know what changes can I do !!!! or any mistake if i have done!!
<img width="1039" height="946" alt="image" src="https://github.com/user-attachments/assets/befbf67a-98a6-425a-b28a-c21f3bbbe19f" />
